### PR TITLE
SHOULD SAY : "The LaTEX source code for this book can be freely acces…

### DIFF
--- a/site/source/tex/clcc-companion.tex
+++ b/site/source/tex/clcc-companion.tex
@@ -501,8 +501,8 @@ This work is distributed under the terms of the Creative Commons license,
 The \href{http://www.latex-project.org/}{\LaTeX} source code for this book can
 be freely accessed on GitHub.
 
-\texttt{\href{https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}
-             {https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}}
+\texttt{\href{https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-companion.tex}
+             {https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-companion.tex}}
 
 \end{center}
 

--- a/site/source/tex/clcc-companion.tex
+++ b/site/source/tex/clcc-companion.tex
@@ -501,8 +501,8 @@ This work is distributed under the terms of the Creative Commons license,
 The \href{http://www.latex-project.org/}{\LaTeX} source code for this book can
 be freely accessed on GitHub.
 
-\texttt{\href{https://github.com/NCCTS/nccts.org/tree/latest/site/source/tex/}
-             {https://github.com/NCCTS/nccts.org/tree/latest/site/source/tex/}}
+\texttt{\href{https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}
+             {https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}}
 
 \end{center}
 


### PR DESCRIPTION
SHOULD SAY : "The LaTEX source code for this book can be freely accessed on GiHub.
https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex"
