### PR TITLE
SHOULD SAY : "The LaTEX source code for this book can be freely acces…

### DIFF
--- a/site/source/tex/clcc-manual.tex
+++ b/site/source/tex/clcc-manual.tex
@@ -109,8 +109,8 @@ e-mail: questions@nccts.org
 The \href{http://www.latex-project.org/}{\LaTeX} source code for this book can
 be freely accessed on GitHub.
 
-\texttt{\href{https://github.com/NCCTS/nccts.org/tree/latest/site/source/tex/}
-             {https://github.com/NCCTS/nccts.org/tree/latest/site/source/tex/}}
+\texttt{\href{https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}
+             {https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex}}
 
 \href{https://creativecommons.org/licenses/by-nc/3.0/}{
   \includegraphics[scale=0.6]{by-nc}


### PR DESCRIPTION
…sed on GiHub.

SHOULD SAY : "The LaTEX source code for this book can be freely accessed on GiHub.
https://github.com/NCCTS/nccts.org/blob/master/site/source/tex/clcc-manual.tex
